### PR TITLE
Keywords article wrapping

### DIFF
--- a/components/articleCard.vue
+++ b/components/articleCard.vue
@@ -39,15 +39,22 @@
 {
     height: 100%;
 }
+
 section h1{
   font-family: FuturaMedium,serif;
   color: rgb(63, 216, 203);
 }
- .title{
+
+.title{
     font-family: MapleRegular,serif !important;
 }
- .subtitle{
+
+.subtitle{
   font-family: MapleRegular,serif !important;
+}
+
+.level-left {
+    width: 100%;
 }
 
 p{


### PR DESCRIPTION
**PR Closes #48** 

Mise en place d'un nouvel attribut dans le conteneur des mots-clefs qui force sa taille à la taille du parent. Le wrapping découle de cette modification.

![wordWrapping](https://user-images.githubusercontent.com/110472580/191207156-26604c2b-6bde-4d63-b51d-84e01e69f242.png)
